### PR TITLE
Implement gait rewards and LSTM

### DIFF
--- a/humanoid/algo/ppo/actor_critic_dh.py
+++ b/humanoid/algo/ppo/actor_critic_dh.py
@@ -60,6 +60,9 @@ class ActorCriticDH(nn.Module):
         # lh_output_dim is cnn output
         # 3 is state estimator output
         mlp_input_dim_a = num_short_obs + lh_output_dim + 3
+        self.rnn_hidden_dim = 128
+        self.lstm = nn.LSTM(mlp_input_dim_a, self.rnn_hidden_dim, batch_first=True)
+        mlp_input_dim_a = self.rnn_hidden_dim
         # num_privileged_obs = int(c_frame_stack * single_num_privileged_obs), 3 history
         mlp_input_dim_c = num_critic_obs
 
@@ -96,6 +99,8 @@ class ActorCriticDH(nn.Module):
         self.distribution = None
         # disable args validation for speedup
         Normal.set_default_validate_args = False
+        self.hx = None
+        self.cx = None
         
         #define long_history CNN
         long_history_layers = []
@@ -140,7 +145,15 @@ class ActorCriticDH(nn.Module):
          enumerate(mod for mod in sequential if isinstance(mod, nn.Linear))]
 
     def reset(self, dones=None):
-        pass
+        if self.hx is None:
+            return
+        if dones is None:
+            self.hx = None
+            self.cx = None
+        else:
+            done_mask = dones.view(1, -1, 1)
+            self.hx = self.hx * (~done_mask)
+            self.cx = self.cx * (~done_mask)
 
     def forward(self):
         raise NotImplementedError
@@ -166,7 +179,14 @@ class ActorCriticDH(nn.Module):
         es_vel = self.state_estimator(short_history)
         compressed_long_history = self.long_history(observations.view(-1, self.in_channels, self.num_proprio_obs))
         actor_obs = torch.cat((short_history, es_vel, compressed_long_history),dim=-1)
-        self.update_distribution(actor_obs)
+        actor_obs_seq = actor_obs.unsqueeze(1)
+        batch = actor_obs_seq.size(0)
+        if self.hx is None or self.hx.size(1) != batch:
+            self.hx = torch.zeros(1, batch, self.rnn_hidden_dim, device=actor_obs.device)
+            self.cx = torch.zeros(1, batch, self.rnn_hidden_dim, device=actor_obs.device)
+        lstm_out, (self.hx, self.cx) = self.lstm(actor_obs_seq, (self.hx, self.cx))
+        actor_feat = lstm_out.squeeze(1)
+        self.update_distribution(actor_feat)
         return self.distribution.sample()
     
     def get_actions_log_prob(self, actions):
@@ -177,7 +197,14 @@ class ActorCriticDH(nn.Module):
         es_vel = self.state_estimator(short_history)
         compressed_long_history = self.long_history(observations.view(-1, self.in_channels, self.num_proprio_obs))
         actor_obs = torch.cat((short_history, es_vel, compressed_long_history),dim=-1)
-        actions_mean = self.actor(actor_obs)
+        actor_obs_seq = actor_obs.unsqueeze(1)
+        batch = actor_obs_seq.size(0)
+        if self.hx is None or self.hx.size(1) != batch:
+            self.hx = torch.zeros(1, batch, self.rnn_hidden_dim, device=actor_obs.device)
+            self.cx = torch.zeros(1, batch, self.rnn_hidden_dim, device=actor_obs.device)
+        lstm_out, (self.hx, self.cx) = self.lstm(actor_obs_seq, (self.hx, self.cx))
+        actor_feat = lstm_out.squeeze(1)
+        actions_mean = self.actor(actor_feat)
         return actions_mean
 
     def evaluate(self, critic_observations, **kwargs):

--- a/humanoid/envs/x1/x1_dh_stand_config.py
+++ b/humanoid/envs/x1/x1_dh_stand_config.py
@@ -185,6 +185,10 @@ class X1DHStandCfg(LeggedRobotCfg):
         push_duration = [0, 0.05, 0.1, 0.15, 0.2, 0.25] # increase push duration during training
         max_push_vel_xy = 0.2
         max_push_ang_vel = 0.2
+        add_ext_force = True
+        ext_force_max_xy = 300
+        ext_force_max_z = 200
+        ext_force_interval_s = 2
 
         randomize_base_mass = True
         added_mass_range = [-3, 3] # base mass rand range, base mass is all fix link sum mass
@@ -337,6 +341,10 @@ class X1DHStandCfg(LeggedRobotCfg):
             vel_mismatch_exp = 0.5  # lin_z; ang x,y
             low_speed = 0.2
             track_vel_hard = 0.5
+            # gait phase
+            cycle_reward = 0.5
+            residual_ang_mom = -0.5
+            symmetry_reward = 0.2
             # base pos
             default_joint_pos = 1.0
             orientation = 1.

--- a/humanoid/envs/x1/x1_dh_stand_env.py
+++ b/humanoid/envs/x1/x1_dh_stand_env.py
@@ -634,7 +634,7 @@ class X1DHStandEnv(LeggedRobot):
 
     def _reward_feet_contact_number(self):
         """
-        Calculates a reward based on the number of feet contacts aligning with the gait phase. 
+        Calculates a reward based on the number of feet contacts aligning with the gait phase.
         Rewards or penalizes depending on whether the foot contact matches the expected gait phase.
         """
         contact = self.contact_forces[:, self.feet_indices, 2] > 5.
@@ -642,6 +642,25 @@ class X1DHStandEnv(LeggedRobot):
         stance_mask[torch.norm(self.commands[:, :3], dim=1) <= self.cfg.commands.stand_com_threshold] = 1
         reward = torch.where(contact == stance_mask, 1, -0.3)
         return torch.mean(reward, dim=1)
+
+    def _reward_cycle_reward(self):
+        """Reward matching the desired swing/stance phase."""
+        contact = self.contact_forces[:, self.feet_indices, 2] > 5.
+        stance_mask = self._get_stance_mask()
+        mismatch = torch.abs(contact.float() - stance_mask)
+        return 1.0 - mismatch.mean(dim=1)
+
+    def _reward_residual_ang_mom(self):
+        """Penalize residual angular momentum."""
+        ang_vel = self.base_ang_vel
+        return torch.sum(torch.square(ang_vel), dim=1)
+
+    def _reward_symmetry_reward(self):
+        """Encourage symmetric joint positions between left and right legs."""
+        left = self.dof_pos[:, :6]
+        right = self.dof_pos[:, 6:]
+        diff = torch.abs(left - right)
+        return -torch.mean(diff, dim=1)
 
     def _reward_orientation(self):
         """


### PR DESCRIPTION
## Summary
- add cyclic gait reward
- penalize residual angular momentum
- reward symmetric joint movement
- use LSTM layer in policy network
- enable external force disturbance in training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ee54cbc48324a93209f6756a1ef9